### PR TITLE
Fix: typscript tutorial final adjustments

### DIFF
--- a/ex0/readme.md
+++ b/ex0/readme.md
@@ -57,7 +57,7 @@ Finally, we will serve the project using ui5.
 ui5 serve
 ```
 
-This command will start a development server for our project. Open the browser and check out the running application! 🚀
+This command will start a development server for our project. Normally, you can access the development server at https://localhost:8080. Open the browser and check out the running application! 🚀
 
 ![Exercise 0 Result](ex0.png)
 

--- a/ex1/readme.md
+++ b/ex1/readme.md
@@ -2,11 +2,11 @@
 [![demo](https://flat.badgen.net/badge/demo/deployed/blue?icon=github)](https://sap-samples.github.io/ui5-mdc-json-tutorial/ex1/dist)
 # Exercise 1: How to Use the MDC Table
 
-This exercise we will learn how to create a JSONTableDelegate for an MDC Table in an XMLView. These elements are crucial when building an MDC application that interfaces with JSON data.
+This exercise we will learn how to create a JSONTableDelegate for an MDC Table in an XMLView. These elements are crucial when building an MDC application that interfacts with JSON data.
 
 ## Step 1: Create a JSONTableDelegate
 
-Firstly, let's create a new JavaScript file named `JSONTableDelegate.ts` inside the `delegate` directory.
+Firstly, let's create a new directory named `delegate` within the `webapp` directory. Also, add a JavaScript file named `JSONTableDelegate.ts` inside the `delegate` directory.
 
 This file serves as a delegate for a UI5 table. Delegates offer a method to customize the behavior of a control without modifying the control itself. In this exampole, it contains the logic of how the table interacts with the sample JSON data.
 
@@ -84,7 +84,7 @@ Next, let's enhance the XML view named `Mountains.view.xml` in the `view` direct
 
 This XML view defines the user interface for a screen in our UI5 application. The view comprises a DynamicPage with a Table control in its content area. The table is set up to use our custom JSONTableDelegate.
 
-Below is the code we can add to content aggregation of the DynamicPage in the XML view. It includes a table with columns for name, height, range, first ascent, countries, and parent mountain, along with the data bindings. The corresponding model is automatically generated based on our sample data via the `manifest.json`.
+Below is the code we can add to the content aggregation of the DynamicPage in the XML view. It includes a table with columns for name, height, range, first ascent, countries, and parent mountain, along with the data bindings. The corresponding model is automatically generated based on our sample data via the `manifest.json`.
 ###### view/Mountains.view.xml
 ```xml
 			<mdc:Table
@@ -135,7 +135,7 @@ Below is the code we can add to content aggregation of the DynamicPage in the XM
 ```
 > ℹ️ Pay attention to how the controls are specified. All the MDCs included in the XML view will initially appear on the screen without any additional personalization. While this may seem superfluous when also providing the control creation method in the delegate, it allows us to establish a default without any hassle. Alternatively, we could opt to not provide any controls here and add them later through personalization.
 
-Run the application and see how with just the few lines of code we added, we get a personalizable table that shows properties of our JSON data! 😱
+Run the application and see how, with just the few lines of code we added, we get a personalizable table that shows properties of our JSON data! 😱
 
 ![Exercise 1 Result](ex1.png)
 ## Summary

--- a/ex2/readme.md
+++ b/ex2/readme.md
@@ -66,7 +66,7 @@ To add a FilterBar to the XML view, we can use the [`sap.ui.mdc.FilterBar`](http
 				</mdc:FilterBar>
 ```
 
-Use the filter association of the table to connect it to the filter bar and add the fields we would like to search in the payload.
+Use the filter association of the table to connect it to the filter bar and add the fields we would like to search in the payload. For this, the `searchKeys` property is added to the delegate payload.
 ###### view/Mountains.view.xml
 ```xml
 			<mdc:Table
@@ -87,7 +87,7 @@ Use the filter association of the table to connect it to the filter bar and add 
 ```
 
 ## Step 3: Enable the Search in the JSONTableDelegate
-To implement the search feature, we need to extend the `JSONTableDelegate` and override the `getFilters` method. We implement a simple search feature by combining several filters and appending them to the regular filter set, which is prepared by the `TableDelegate`. Furthermore, we will extend interface of the `TablePayload`, which then should also contain the information about the `searchKeys`.
+To implement the search feature, we need to extend the `JSONTableDelegate` and override the `getFilters` method. We implement a simple search feature by combining several filters and appending them to the regular filter set, which is prepared by the `TableDelegate`. Furthermore, we will extend the interface of the `TablePayload`, which then should also contain the information about the `searchKeys`. At this point you might need to add missing imports for `Filter`, `FilterOperator`, and `FilterBar`, which you can either do manually or use the "Quick Fix" feature of e.g. Visual Studio Code.
 
 ###### delegate/JSONTableDelegate.ts
 ```typescript
@@ -115,7 +115,7 @@ JSONTableDelegate.getFilters = (oTable) => {
 	return aFilters
 }
 ```
-At this point you might need to add missing imports for `Filter`, `FilterOperator`, and `FilterBar`, which you can either do manually or use the "Quick Fix" feature of e.g. Visual Studio Code. Now go and try out the filter and search functionality in our application. The table should display only the filtered items! 🙌
+Now go and try out the filter and search functionality in our application. The table should display only the filtered items! 🙌
 
 ![Exercise 2 Result](ex2.png)
 

--- a/ex3/readme.md
+++ b/ex3/readme.md
@@ -132,6 +132,7 @@ To utilize the advanced value help in our view, we need to attach it as a depend
 					</mdc:dependents>
 ```
 Subsequently, it is crucial to connect the value help to the corresponding filter field by setting the `valueHelp` association. For the other value help, we are going to use a delegate-based method in the next step.
+###### view/Mountains.view.xml
 ```xml
 						<mdc:FilterField
 							label="Name"
@@ -142,7 +143,7 @@ Subsequently, it is crucial to connect the value help to the corresponding filte
 							delegate="{name: 'sap/ui/mdc/field/FieldBaseDelegate'}"/>
 ```
 ## Step 3: Incorporate Payload
-To determine in our delegate which properties should be associated with a value help, we can define a delegate-specific payload for this particular table instance. The payload can be added as follows:
+To determine which properties should be associated with a value help in our delegate, we can define a delegate-specific payload for this particular table instance. The payload can be added as follows:
 ###### view/Mountains.view.xml
 ```xml
                 <mdc:FilterBar id="filterbar" delegate="{
@@ -158,7 +159,7 @@ To determine in our delegate which properties should be associated with a value 
 ```
 ## Step 4: Add Value Help Creation in Delegate
 Accessing the payload allows us to identify if a specific filter field requires a value help if created by the delegate. Using this information, we can tie the filter field to the value help and attach it as a dependent to the filter bar, but this time within the appropriate callback. Replace the old implementation of `_createFilterField` as follows and add a interface for the `FilterBarPayload`, which defines its content:
-###### delegate/JSONTableDelegate.ts
+###### delegate/JSONFilterBarDelegate.ts
 ```typescript
 interface FilterBarPayload {
 	valueHelp: {

--- a/ex5/readme.md
+++ b/ex5/readme.md
@@ -13,7 +13,7 @@ We'll utilize the `sap/ui/fl/variants/VariantManagement` control. This does not 
 				</f:heading>
 			</f:DynamicPageTitle>
 ```
-Try it and create your favorite variant! How easy was that? 😎
+Try it and create your favorite variant! How easy was that? 😎 The following image shows a custom variant named "Very High Mountains" that adds a FilterField for the `Height` property.
 
 ![Exercise 5 Result](ex5.png)
 


### PR DESCRIPTION
Some things to improve:
- [x] General proposal: rename to folders of the exercise to depict what they are dealing with. For example: `ex4-custom-types` instead of `ex` 
- [x] ex2: `delegate/JSONFilterBarDelegate` shows an error, as the types for the FilterBarDelegate are missing. Is there any way to fix this? (see image below)
![img](https://github.com/SAP-samples/ui5-mdc-json-tutorial/assets/49287189/3a106767-e538-4b6a-9186-682e3327a7cf)
- [ ] ex3: a value help for the range is created, however it is not used. Is this intended?