### PR TITLE
Fix table flickering

### DIFF
--- a/u1/ex0/webapp/view/Mountains.view.xml
+++ b/u1/ex0/webapp/view/Mountains.view.xml
@@ -10,16 +10,13 @@
 	xmlns:vm="sap.ui.fl.variants">
 
 	<f:DynamicPage id="page">
-		<f:title>
-			<f:DynamicPageTitle>
-				<f:heading>
-					<Title text="Mountains"/>
-				</f:heading>
-			</f:DynamicPageTitle>
-		</f:title>
 		<f:header>
 			<f:DynamicPageHeader pinnable="true">
-				
+					<f:DynamicPageTitle>
+					<f:heading>
+						<Title text="Mountains"/>
+					</f:heading>
+				</f:DynamicPageTitle>
 			</f:DynamicPageHeader>
 		</f:header>
 		<f:content>

--- a/u1/ex1/webapp/view/Mountains.view.xml
+++ b/u1/ex1/webapp/view/Mountains.view.xml
@@ -10,26 +10,22 @@
 	xmlns:vm="sap.ui.fl.variants">
 
 	<f:DynamicPage id="page">
-		<f:title>
-			<f:DynamicPageTitle>
-				<f:heading>
-					<Title text="Mountains"/>
-				</f:heading>
-			</f:DynamicPageTitle>
-		</f:title>
 		<f:header>
 			<f:DynamicPageHeader pinnable="true">
-				
+					<f:DynamicPageTitle>
+					<f:heading>
+						<Title text="Mountains"/>
+					</f:heading>
+				</f:DynamicPageTitle>
 			</f:DynamicPageHeader>
 		</f:header>
 		<f:content>
-			<mdc:Table
+				<mdc:Table
 				id="table"
 				header="Mountains"
 				p13nMode="Sort,Column"
 				type="ResponsiveTable"
 				threshold="100"
-				filter="filterbar"
 				showRowCount="false"
 				delegate="{
 					name: 'mdc/tutorial/delegate/JSONTableDelegate',

--- a/u1/ex2/webapp/view/Mountains.view.xml
+++ b/u1/ex2/webapp/view/Mountains.view.xml
@@ -10,15 +10,13 @@
 	xmlns:vm="sap.ui.fl.variants">
 
 	<f:DynamicPage id="page">
-		<f:title>
-			<f:DynamicPageTitle>
-				<f:heading>
-					<Title text="Mountains"/>
-				</f:heading>
-			</f:DynamicPageTitle>
-		</f:title>
 		<f:header>
 			<f:DynamicPageHeader pinnable="true">
+					<f:DynamicPageTitle>
+					<f:heading>
+						<Title text="Mountains"/>
+					</f:heading>
+				</f:DynamicPageTitle>
 				<mdc:FilterBar id="filterbar" delegate="{name: 'mdc/tutorial/delegate/JSONFilterBarDelegate'}"
 						p13nMode = "Item,Value">
 					<mdc:basicSearchField>

--- a/u1/ex3/webapp/view/Mountains.view.xml
+++ b/u1/ex3/webapp/view/Mountains.view.xml
@@ -10,15 +10,13 @@
 	xmlns:vm="sap.ui.fl.variants">
 
 	<f:DynamicPage id="page">
-		<f:title>
-			<f:DynamicPageTitle>
-				<f:heading>
-					<Title text="Mountains"/>
-				</f:heading>
-			</f:DynamicPageTitle>
-		</f:title>
 		<f:header>
 			<f:DynamicPageHeader pinnable="true">
+					<f:DynamicPageTitle>
+					<f:heading>
+						<Title text="Mountains"/>
+					</f:heading>
+				</f:DynamicPageTitle>
 				<mdc:FilterBar id="filterbar" delegate="{
 							name: 'mdc/tutorial/delegate/JSONFilterBarDelegate',
 							payload: {

--- a/u1/ex4/webapp/view/Mountains.view.xml
+++ b/u1/ex4/webapp/view/Mountains.view.xml
@@ -10,15 +10,13 @@
 	xmlns:vm="sap.ui.fl.variants">
 
 	<f:DynamicPage id="page">
-		<f:title>
-			<f:DynamicPageTitle>
-				<f:heading>
-					<Title text="Mountains"/>
-				</f:heading>
-			</f:DynamicPageTitle>
-		</f:title>
 		<f:header>
 			<f:DynamicPageHeader pinnable="true">
+					<f:DynamicPageTitle>
+					<f:heading>
+						<Title text="Mountains"/>
+					</f:heading>
+				</f:DynamicPageTitle>
 				<mdc:FilterBar id="filterbar" delegate="{
 							name: 'mdc/tutorial/delegate/JSONFilterBarDelegate',
 							payload: {

--- a/u1/ex5/webapp/view/Mountains.view.xml
+++ b/u1/ex5/webapp/view/Mountains.view.xml
@@ -10,15 +10,13 @@
 	xmlns:vm="sap.ui.fl.variants">
 
 	<f:DynamicPage id="page">
-		<f:title>
-			<f:DynamicPageTitle>
-				<f:heading>
-					<vm:VariantManagement id="variants" for="filterbar, table"/>
-				</f:heading>
-			</f:DynamicPageTitle>
-		</f:title>
 		<f:header>
 			<f:DynamicPageHeader pinnable="true">
+					<f:DynamicPageTitle>
+					<f:heading>
+						<vm:VariantManagement id="variants" for="filterbar, table"/>
+					</f:heading>
+				</f:DynamicPageTitle>
 				<mdc:FilterBar id="filterbar" delegate="{
 							name: 'mdc/tutorial/delegate/JSONFilterBarDelegate',
 							payload: {


### PR DESCRIPTION
The current use of f:title and f:header caused the page to trigger an infinite reload which was visible in a flickering of the table within the exercises 1 to 5 of unit 1.

This PR fixes that problem by placing the DynamicPageTitle inside the PageHeader instead of an title element. 
